### PR TITLE
Support JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Supported schemas are below.
 - `raw`
 - `excel`
 - `orc`
+- `json`
 
 `tsv` plugin extract each line with `\t` delimiter. Currently first line is used as column names.
 ```sql

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 

--- a/src/main/java/org/ebyhr/trino/storage/FileType.java
+++ b/src/main/java/org/ebyhr/trino/storage/FileType.java
@@ -17,7 +17,7 @@ import static java.util.Locale.ENGLISH;
 
 public enum FileType
 {
-    CSV, TSV, TXT, RAW, EXCEL, ORC;
+    CSV, TSV, TXT, RAW, EXCEL, ORC, JSON;
 
     @Override
     public String toString()

--- a/src/main/java/org/ebyhr/trino/storage/StorageClient.java
+++ b/src/main/java/org/ebyhr/trino/storage/StorageClient.java
@@ -26,6 +26,7 @@ import javax.net.ssl.HttpsURLConnection;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URL;
 import java.util.HashSet;
@@ -34,6 +35,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class StorageClient
@@ -67,8 +69,8 @@ public class StorageClient
         requireNonNull(tableName, "tableName is null");
 
         FilePlugin plugin = PluginFactory.create(schema);
-        try (InputStream inputStream = getInputStream(session, tableName)) {
-            List<StorageColumn> columns = plugin.getFields(inputStream);
+        try {
+            List<StorageColumn> columns = plugin.getFields(tableName, path -> getInputStream(session, path));
             return new StorageTable(tableName, columns);
         }
         catch (Exception e) {
@@ -96,7 +98,7 @@ public class StorageClient
             return URI.create(path).toURL().openStream();
         }
         catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new UncheckedIOException(format("Failed to open stream for %s", path), e);
         }
     }
 }

--- a/src/main/java/org/ebyhr/trino/storage/operator/CsvPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/CsvPlugin.java
@@ -34,11 +34,11 @@ public class CsvPlugin
     private static final String DELIMITER = ",";
 
     @Override
-    public List<StorageColumn> getFields(InputStream inputStream)
+    public List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider)
     {
         Splitter splitter = Splitter.on(DELIMITER).trimResults();
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(streamProvider.apply(path)))) {
             List<String> fields = splitter.splitToList(reader.readLine());
             return fields.stream()
                     .map(field -> new StorageColumn(field, VARCHAR))

--- a/src/main/java/org/ebyhr/trino/storage/operator/ExcelPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/ExcelPlugin.java
@@ -42,8 +42,9 @@ public class ExcelPlugin
     private static final DataFormatter DATA_FORMATTER = new DataFormatter();
 
     @Override
-    public List<StorageColumn> getFields(InputStream inputStream)
+    public List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider)
     {
+        InputStream inputStream = streamProvider.apply(path);
         try {
             Workbook workbook = WorkbookFactory.create(inputStream);
             Sheet sheet = workbook.getSheetAt(0);

--- a/src/main/java/org/ebyhr/trino/storage/operator/FilePlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/FilePlugin.java
@@ -23,7 +23,7 @@ import java.util.stream.Stream;
 
 public interface FilePlugin
 {
-    List<StorageColumn> getFields(InputStream inputStream);
+    List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider);
 
     default Stream<List<?>> getRecordsIterator(String path, Function<String, InputStream> streamProvider)
     {

--- a/src/main/java/org/ebyhr/trino/storage/operator/JsonPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/JsonPlugin.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ebyhr.trino.storage.operator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.Streams;
+import io.airlift.slice.Slice;
+import io.trino.spi.TrinoException;
+import io.trino.spi.block.BlockBuilder;
+import io.trino.spi.type.ArrayType;
+import io.trino.spi.type.BooleanType;
+import io.trino.spi.type.RowType;
+import io.trino.spi.type.Type;
+import org.ebyhr.trino.storage.StorageColumn;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.UncheckedIOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.trino.spi.StandardErrorCode.TYPE_MISMATCH;
+import static io.trino.spi.type.BigintType.BIGINT;
+import static io.trino.spi.type.DoubleType.DOUBLE;
+import static io.trino.spi.type.VarcharType.VARCHAR;
+
+public class JsonPlugin
+        implements FilePlugin
+{
+    @Override
+    public List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider)
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(streamProvider.apply(path)))) {
+            // check for lines up to 1MB
+            reader.mark(1024 * 1024);
+            String firstLine = reader.readLine();
+            JsonNode node;
+            try {
+                node = objectMapper.readTree(firstLine);
+            }
+            catch (JsonProcessingException e) {
+                // try to read whole file and assume there's an array of objects, so get the first one
+                reader.reset();
+                JsonNode root = objectMapper.readTree(reader);
+                Iterator<JsonNode> elements = root.elements();
+                if (!elements.hasNext()) {
+                    return List.of();
+                }
+                node = elements.next();
+            }
+            return Streams.stream(node.fields())
+                    .map(entry -> new StorageColumn(entry.getKey(), mapType(entry.getValue())))
+                    .collect(toImmutableList());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private Type mapType(JsonNode node)
+    {
+        switch (node.getNodeType()) {
+            case ARRAY:
+                Iterator<JsonNode> elements = node.elements();
+                if (!elements.hasNext()) {
+                    throw new VerifyException("Cannot infer the SQL type of an empty JSON array");
+                }
+                return new ArrayType(mapType(elements.next()));
+            case BOOLEAN:
+                return BooleanType.BOOLEAN;
+            case NUMBER:
+                return node.canConvertToLong() ? BIGINT : DOUBLE;
+            case OBJECT:
+                List<RowType.Field> fields = Streams.stream(node.fields())
+                        .map(entry -> new RowType.Field(Optional.of(entry.getKey()), mapType(entry.getValue())))
+                        .collect(toImmutableList());
+                return RowType.from(fields);
+            case NULL:
+            case STRING:
+                return VARCHAR;
+            // BINARY, MISSING, POJO
+            default:
+                throw new VerifyException("Unhandled JSON type: " + node.getNodeType());
+        }
+    }
+
+    @Override
+    public Stream<List<?>> getRecordsIterator(String path, Function<String, InputStream> streamProvider)
+    {
+        ObjectMapper objectMapper = new ObjectMapper();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(streamProvider.apply(path)));
+        try {
+            // check for lines up to 1MB
+            reader.mark(1024 * 1024);
+            String firstLine = reader.readLine();
+            try {
+                // try parsing the first line only to confirm this is a JSONL file, so throw away the result
+                objectMapper.readTree(firstLine);
+                reader.reset();
+                return reader.lines().map(node -> {
+                    try {
+                        return nodeToRow(objectMapper.readTree(node));
+                    }
+                    catch (JsonProcessingException e) {
+                        throw new TrinoException(TYPE_MISMATCH, e);
+                    }
+                });
+            }
+            catch (JsonProcessingException e) {
+                // try to read whole file and assume there's an array of objects, so get the first one
+                reader.reset();
+                JsonNode root = objectMapper.readTree(reader);
+                return Streams.stream(root.elements())
+                        .map(this::nodeToRow);
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private List<?> nodeToRow(JsonNode node)
+    {
+        return Streams.stream(node.fields())
+                .map(entry -> mapValue(entry.getValue()))
+                .collect(Collectors.toList());
+    }
+
+    private Object mapValue(JsonNode node)
+    {
+        BlockBuilder values;
+        switch (node.getNodeType()) {
+            case ARRAY:
+                Iterator<JsonNode> elements = node.elements();
+                if (!elements.hasNext()) {
+                    throw new VerifyException("Cannot infer the SQL type of an empty JSON array");
+                }
+                Type type = mapType(elements.next());
+                values = type.createBlockBuilder(null, 10);
+                node.elements().forEachRemaining(value -> writeObject(values, value));
+                return values.build();
+            case BOOLEAN:
+                return node.asBoolean();
+            case NUMBER:
+                return node.canConvertToLong() ? node.asLong() : node.asDouble();
+            case OBJECT:
+                Type rowType = mapType(node);
+                values = rowType.createBlockBuilder(null, 10);
+                BlockBuilder rowBuilder = values.beginBlockEntry();
+                node.fields().forEachRemaining(field -> writeObject(rowBuilder, field.getValue()));
+                values.closeEntry();
+                return rowType.getObject(values, values.getPositionCount() - 1);
+            case NULL:
+                return null;
+            case STRING:
+                return node.asText();
+            default:
+                // BINARY, MISSING, POJO
+                throw new VerifyException("Unhandled JSON type: " + node.getNodeType());
+        }
+    }
+
+    private void writeObject(BlockBuilder blockBuilder, JsonNode node)
+    {
+        Type type = mapType(node);
+        Object value = mapValue(node);
+        Class<?> javaType = type.getJavaType();
+
+        if (javaType == long.class) {
+            BIGINT.writeLong(blockBuilder, (long) value);
+        }
+        else if (javaType == double.class) {
+            DOUBLE.writeDouble(blockBuilder, (double) value);
+        }
+        else if (javaType == boolean.class) {
+            BooleanType.BOOLEAN.writeBoolean(blockBuilder, (Boolean) value);
+        }
+        else if (javaType == Slice.class) {
+            VARCHAR.writeString(blockBuilder, (String) value);
+        }
+        else if (!javaType.isPrimitive()) {
+            type.writeObject(blockBuilder, mapValue(node));
+        }
+        else {
+            throw new IllegalArgumentException("Unknown java type " + javaType + " from type " + type);
+        }
+    }
+}

--- a/src/main/java/org/ebyhr/trino/storage/operator/PluginFactory.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/PluginFactory.java
@@ -36,6 +36,8 @@ public final class PluginFactory
                 return new ExcelPlugin();
             case "orc":
                 return new OrcPlugin();
+            case "json":
+                return new JsonPlugin();
             default:
                 throw new SchemaNotFoundException(typeName);
         }

--- a/src/main/java/org/ebyhr/trino/storage/operator/RawPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/RawPlugin.java
@@ -30,7 +30,7 @@ public class RawPlugin
         implements FilePlugin
 {
     @Override
-    public List<StorageColumn> getFields(InputStream inputStream)
+    public List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider)
     {
         return List.of(new StorageColumn("data", VARCHAR));
     }

--- a/src/main/java/org/ebyhr/trino/storage/operator/TextPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/TextPlugin.java
@@ -28,7 +28,7 @@ public class TextPlugin
         implements FilePlugin
 {
     @Override
-    public List<StorageColumn> getFields(InputStream inputStream)
+    public List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider)
     {
         return List.of(new StorageColumn("value", VARCHAR));
     }

--- a/src/main/java/org/ebyhr/trino/storage/operator/TsvPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/TsvPlugin.java
@@ -34,11 +34,11 @@ public class TsvPlugin
     private static final String DELIMITER = "\t";
 
     @Override
-    public List<StorageColumn> getFields(InputStream inputStream)
+    public List<StorageColumn> getFields(String path, Function<String, InputStream> streamProvider)
     {
         Splitter splitter = Splitter.on(DELIMITER).trimResults();
 
-        try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(streamProvider.apply(path)))) {
             List<String> fields = splitter.splitToList(reader.readLine());
             return fields.stream()
                     .map(field -> new StorageColumn(field, VARCHAR))

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageClient.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageClient.java
@@ -36,6 +36,6 @@ public class TestStorageClient
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
 
         StorageClient client = new StorageClient(hdfsEnvironment);
-        assertEquals(client.getSchemaNames(), List.of("csv", "tsv", "txt", "raw", "excel", "orc"));
+        assertEquals(client.getSchemaNames(), List.of("csv", "tsv", "txt", "raw", "excel", "orc", "json"));
     }
 }

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageConnector.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageConnector.java
@@ -70,6 +70,22 @@ public final class TestStorageConnector
                 "VALUES (1658882660, 639, -5557347160648450358)");
     }
 
+    @Test
+    public void testSelectJson()
+    {
+        // note that empty arrays are not supported at all, because array types are inferred from the first array element
+        assertQuery(
+                format("SELECT * FROM storage.json.\"%s\"", toAbsolutePath("example-data/newlines.json")),
+                "VALUES " +
+                        "(true, CAST(null AS VARCHAR), 'aaa', 5, CAST(123.456 AS double), ARRAY['aaa', 'bbb']), " +
+                        "(false, CAST(null AS VARCHAR), 'bbb', 10, CAST(123.456 AS double), ARRAY['ccc'])");
+        assertQuery(
+                format("SELECT * FROM storage.json.\"%s\"", toAbsolutePath("example-data/array-of-objects.json")),
+                "VALUES " +
+                        "(true, CAST(null AS VARCHAR), 'aaa', 5, CAST(123.456 AS double), ARRAY['aaa', 'bbb']), " +
+                        "(false, CAST(null AS VARCHAR), 'bbb', 10, CAST(123.456 AS double), ARRAY['ccc'])");
+    }
+
     private static String toAbsolutePath(String resourceName)
     {
         return Resources.getResource(resourceName).toString();

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageMetadata.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageMetadata.java
@@ -71,7 +71,7 @@ public class TestStorageMetadata
     @Test
     public void testListSchemaNames()
     {
-        assertThat(metadata.listSchemaNames(SESSION)).containsOnly("csv", "tsv", "txt", "raw", "excel", "orc");
+        assertThat(metadata.listSchemaNames(SESSION)).containsOnly("csv", "tsv", "txt", "raw", "excel", "orc", "json");
     }
 
     @Test

--- a/src/test/resources/example-data/array-of-objects.json
+++ b/src/test/resources/example-data/array-of-objects.json
@@ -1,0 +1,4 @@
+[
+  {"bool": true, "null": null, "string":  "aaa", "int":  5, "double":  123.456, "array of strings":  ["aaa", "bbb"]},
+  {"bool": false, "null": null, "string":  "bbb", "int":  10, "double":  123.456, "array of strings":  ["ccc"]}
+]

--- a/src/test/resources/example-data/newlines.json
+++ b/src/test/resources/example-data/newlines.json
@@ -1,0 +1,2 @@
+{"bool": true, "null": null, "string":  "aaa", "int":  5, "double":  123.456, "array of strings":  ["aaa", "bbb"]}
+{"bool": false, "null": null, "string":  "bbb", "int":  10, "double":  123.456, "array of strings":  ["ccc"]}


### PR DESCRIPTION
Support JSON files, both JSONL (newline-separated JSON) and regular JSON files with an array of objects.

Types are inferred from the first line/object, so this comes with a lot of limitations. For example, arrays are supported, but not empty ones, which will be quite surprising to users.