### PR TITLE
Update dependencies

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/README.md
+++ b/README.md
@@ -108,5 +108,9 @@ Build without running tests
 ./mvnw clean install -DskipTests
 ```
 
+> Note: tests include intergration tests, that will run Minio and HDFS as Docker containers. They need to pull their images,
+> which can take a while. If you see the tests getting stuck, try pulling these images before starting tests, to see the progress.
+> Look for image names and versions in `TestingMinioServer` and `TestingHadoopServer` test classes.
+
 # Deploy
 Unarchive trino-storage-{version}.zip and copy jar files in target directory to use storage connector in your Trino cluster.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.ebyhr</groupId>
     <artifactId>trino-storage</artifactId>
-    <version>392-SNAPSHOT</version>
+    <version>393-SNAPSHOT</version>
     <description>Trino - Storage Connector</description>
     <packaging>trino-plugin</packaging>
 
@@ -28,7 +28,8 @@
     </licenses>
 
     <properties>
-        <project.build.targetJdk>11</project.build.targetJdk>
+        <project.build.targetJdk>17</project.build.targetJdk>
+        <air.java.version>17.0.4</air.java.version>
 
         <air.check.skip-extended>true</air.check.skip-extended>
         <air.check.skip-license>false</air.check.skip-license>
@@ -36,12 +37,12 @@
         <air.check.fail-checkstyle>true</air.check.fail-checkstyle>
         <air.check.skip-checkstyle>false</air.check.skip-checkstyle>
 
-        <dep.trino.version>391</dep.trino.version>
-        <dep.airlift.version>217</dep.airlift.version>
+        <dep.trino.version>393</dep.trino.version>
+        <dep.airlift.version>218</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
-        <dep.aws-sdk.version>1.12.267</dep.aws-sdk.version>
+        <dep.aws-sdk.version>1.12.286</dep.aws-sdk.version>
+        <dep.errorprone.version>2.15.0</dep.errorprone.version>
         <dep.jackson.version>2.13.3</dep.jackson.version>
-        <dep.errorprone.version>2.14.0</dep.errorprone.version>
         <dep.testcontainers.version>1.17.3</dep.testcontainers.version>
         <dep.docker-java.version>3.2.13</dep.docker-java.version>
         <dep.testng.version>7.6.1</dep.testng.version>
@@ -67,7 +68,7 @@
             <dependency>
                 <groupId>org.checkerframework</groupId>
                 <artifactId>checker-qual</artifactId>
-                <version>3.22.2</version>
+                <version>3.24.0</version>
             </dependency>
             <dependency>
                 <groupId>com.github.spotbugs</groupId>
@@ -78,6 +79,12 @@
     </dependencyManagement>
 
     <dependencies>
+        <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-hdfs</artifactId>
+            <version>${dep.trino.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>io.trino</groupId>
             <artifactId>trino-hive</artifactId>
@@ -181,7 +188,7 @@
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.10.14</version>
+            <version>2.11.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/org/ebyhr/trino/storage/StorageClient.java
+++ b/src/main/java/org/ebyhr/trino/storage/StorageClient.java
@@ -14,8 +14,8 @@
 package org.ebyhr.trino.storage;
 
 import io.airlift.log.Logger;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.HdfsEnvironment.HdfsContext;
+import io.trino.hdfs.HdfsContext;
+import io.trino.hdfs.HdfsEnvironment;
 import io.trino.spi.connector.ConnectorSession;
 import org.apache.hadoop.fs.Path;
 import org.ebyhr.trino.storage.operator.FilePlugin;

--- a/src/main/java/org/ebyhr/trino/storage/StorageConnectorFactory.java
+++ b/src/main/java/org/ebyhr/trino/storage/StorageConnectorFactory.java
@@ -16,8 +16,8 @@ package org.ebyhr.trino.storage;
 import com.google.inject.Injector;
 import io.airlift.bootstrap.Bootstrap;
 import io.airlift.json.JsonModule;
-import io.trino.plugin.hive.HiveHdfsModule;
-import io.trino.plugin.hive.authentication.HdfsAuthenticationModule;
+import io.trino.hdfs.HdfsModule;
+import io.trino.hdfs.authentication.HdfsAuthenticationModule;
 import io.trino.plugin.hive.azure.HiveAzureModule;
 import io.trino.plugin.hive.gcs.HiveGcsModule;
 import io.trino.plugin.hive.s3.HiveS3Module;
@@ -48,7 +48,7 @@ public class StorageConnectorFactory
             Bootstrap app = new Bootstrap(
                     new JsonModule(),
                     new StorageModule(catalogName, context.getTypeManager()),
-                    new HiveHdfsModule(),
+                    new HdfsModule(),
                     new HiveS3Module(),
                     new HiveGcsModule(),
                     new HiveAzureModule(),

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageClient.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageClient.java
@@ -14,12 +14,12 @@
 package org.ebyhr.trino.storage;
 
 import com.google.common.collect.ImmutableSet;
-import io.trino.plugin.hive.HdfsConfig;
-import io.trino.plugin.hive.HdfsConfiguration;
-import io.trino.plugin.hive.HdfsConfigurationInitializer;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.HiveHdfsConfiguration;
-import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.hdfs.DynamicHdfsConfiguration;
+import io.trino.hdfs.HdfsConfig;
+import io.trino.hdfs.HdfsConfiguration;
+import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.hdfs.authentication.NoHdfsAuthentication;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -32,7 +32,7 @@ public class TestStorageClient
     public void testMetadata()
     {
         HdfsConfig config = new HdfsConfig();
-        HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
+        HdfsConfiguration configuration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
 
         StorageClient client = new StorageClient(hdfsEnvironment);

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageMetadata.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageMetadata.java
@@ -15,12 +15,12 @@ package org.ebyhr.trino.storage;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
-import io.trino.plugin.hive.HdfsConfig;
-import io.trino.plugin.hive.HdfsConfiguration;
-import io.trino.plugin.hive.HdfsConfigurationInitializer;
-import io.trino.plugin.hive.HdfsEnvironment;
-import io.trino.plugin.hive.HiveHdfsConfiguration;
-import io.trino.plugin.hive.authentication.NoHdfsAuthentication;
+import io.trino.hdfs.DynamicHdfsConfiguration;
+import io.trino.hdfs.HdfsConfig;
+import io.trino.hdfs.HdfsConfiguration;
+import io.trino.hdfs.HdfsConfigurationInitializer;
+import io.trino.hdfs.HdfsEnvironment;
+import io.trino.hdfs.authentication.NoHdfsAuthentication;
 import io.trino.spi.TrinoException;
 import io.trino.spi.connector.ColumnMetadata;
 import io.trino.spi.connector.ConnectorTableMetadata;
@@ -61,7 +61,7 @@ public class TestStorageMetadata
         assertNotNull(metadataUrl, "metadataUrl is null");
 
         HdfsConfig config = new HdfsConfig();
-        HdfsConfiguration configuration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
+        HdfsConfiguration configuration = new DynamicHdfsConfiguration(new HdfsConfigurationInitializer(config), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(configuration, config, new NoHdfsAuthentication());
 
         StorageClient client = new StorageClient(hdfsEnvironment);

--- a/src/test/java/org/ebyhr/trino/storage/TestingHadoopServer.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestingHadoopServer.java
@@ -40,7 +40,7 @@ public class TestingHadoopServer
 
     public TestingHadoopServer(Network network)
     {
-        dockerContainer = new GenericContainer<>(DockerImageName.parse("ghcr.io/trinodb/testing/hdp2.6-hive:50"))
+        dockerContainer = new GenericContainer<>(DockerImageName.parse("ghcr.io/trinodb/testing/hdp2.6-hive:65"))
                 .withCreateContainerCmdModifier(cmd -> cmd.withHostName(HOSTNAME))
                 .withCopyFileToContainer(MountableFile.forClasspathResource("minio/hive-core-site.xml"), "/etc/hadoop/conf/core-site.xml")
                 .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())

--- a/src/test/java/org/ebyhr/trino/storage/TestingMinioServer.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestingMinioServer.java
@@ -34,7 +34,7 @@ public class TestingMinioServer
     public static final String ACCESS_KEY = "accesskey";
     public static final String SECRET_KEY = "secretkey";
 
-    private static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2021-07-15T22-27-34Z";
+    private static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2022-08-13T21-54-44Z";
     private static final String HOSTNAME = "minio";
 
     private static final int API_PORT = 4566;


### PR DESCRIPTION
Note that updating Trino from 391 to 393 changes the required JDK from 11 to 17.