### PR TITLE
Include poi-ooxml at runtime, not just tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,13 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.3</version>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <version>1.10</version>
@@ -345,13 +352,6 @@
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
             <version>5.13.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml</artifactId>
-            <version>5.2.3</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
We have `poi-ooxml` only included in the test scope, that's why tests pass, but we get this error when deploying the plugin with Trino.

Fixes #205 and #199 