### PR TITLE
Use jackson-dataformat-csv for csv/ssv/tsv handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-csv</artifactId>
+            <version>${dep.jackson.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${dep.guava.version}</version>

--- a/src/main/java/org/ebyhr/trino/storage/operator/CsvPlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/CsvPlugin.java
@@ -33,16 +33,14 @@ import static io.trino.spi.type.VarcharType.VARCHAR;
 public class CsvPlugin
         implements FilePlugin
 {
-    private final String delimiter;
     private final CsvMapper mapper;
     private final CsvSchema schema;
 
-    public CsvPlugin(String delimiter)
+    public CsvPlugin(char delimiter)
     {
-        this.delimiter = delimiter;
         this.mapper = new CsvMapper();
         this.mapper.enable(CsvParser.Feature.WRAP_AS_ARRAY).enable(CsvParser.Feature.TRIM_SPACES);
-        this.schema = CsvSchema.emptySchema().withColumnSeparator(this.delimiter.charAt(0));
+        this.schema = CsvSchema.emptySchema().withColumnSeparator(delimiter);
     }
 
     @Override

--- a/src/main/java/org/ebyhr/trino/storage/operator/PluginFactory.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/PluginFactory.java
@@ -25,11 +25,11 @@ public final class PluginFactory
     {
         switch (typeName.toLowerCase(ENGLISH)) {
             case "csv":
-                return new CsvPlugin(",");
+                return new CsvPlugin(',');
             case "tsv":
-                return new CsvPlugin("\t");
+                return new CsvPlugin('\t');
             case "ssv":
-                return new CsvPlugin(";");
+                return new CsvPlugin(';');
             case "txt":
                 return new TextPlugin();
             case "raw":

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageConnector.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageConnector.java
@@ -46,6 +46,13 @@ public final class TestStorageConnector
         assertQuery(
                 "SELECT * FROM TABLE(storage.system.read_file('csv', '" + toAbsolutePath("example-data/numbers-2.csv") + "'))",
                 "VALUES ('eleven', '11'), ('twelve', '12')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('csv', '" + toAbsolutePath("example-data/quoted_fields_with_separator.csv") + "'))",
+                "VALUES ('test','2','3','4'),('test,test,test,test','3','3','5'),(' even weirder, but still valid, value with extra whitespaces that remain due to quoting /  ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('csv', '" + toAbsolutePath("example-data/quoted_fields_with_newlines.csv") + "'))",
+                "VALUES ('test','2','3','4'),('test,test,test,test','3','3','5'),(' even weirder, but still valid, value with linebreaks and extra\n" +
+                        "whitespaces that should remain due to quoting   ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
     }
 
     @Test
@@ -54,6 +61,13 @@ public final class TestStorageConnector
         assertQuery(
                 "SELECT * FROM TABLE(storage.system.read_file('ssv', '" + toAbsolutePath("example-data/numbers-2.ssv") + "'))",
                 "VALUES ('eleven', '11'), ('twelve', '12')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('ssv', '" + toAbsolutePath("example-data/quoted_fields_with_separator.ssv") + "'))",
+                "VALUES ('test','2','3','4'),('test;test;test;test','3','3','5'),(' even weirder; but still valid; value with extra whitespaces that remain due to quoting /  ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('ssv', '" + toAbsolutePath("example-data/quoted_fields_with_newlines.ssv") + "'))",
+                "VALUES ('test','2','3','4'),('test;test;test;test','3','3','5'),(' even weirder, but still valid; value with linebreaks and extra\n" +
+                        " whitespaces that should remain due to quoting   ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
     }
 
     @Test
@@ -65,6 +79,13 @@ public final class TestStorageConnector
         assertQuery(
                 "SELECT * FROM TABLE(storage.system.read_file('tsv', '" + server.getHadoopServer().toHdfsPath("/tmp/numbers.tsv") + "'))",
                 "VALUES ('two', '2'), ('three', '3')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('tsv', '" + toAbsolutePath("example-data/quoted_fields_with_separator.tsv") + "'))",
+                "VALUES ('test','2','3','4'),('test\ttest\ttest\ttest','3','3','5'),(' even weirder\t but still valid\t value with extra whitespaces that remain due to quoting /  ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('tsv', '" + toAbsolutePath("example-data/quoted_fields_with_newlines.tsv") + "'))",
+                "VALUES ('test','2','3','4'),('test\ttest\ttest\ttest','3','3','5'),(' even weirder, but still valid, value with linebreaks and extra\n" +
+                        " whitespaces that should remain due to quoting   ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
     }
 
     @Test

--- a/src/test/resources/example-data/quoted_fields_with_newlines.csv
+++ b/src/test/resources/example-data/quoted_fields_with_newlines.csv
@@ -1,0 +1,6 @@
+header_1,header_2,"weird, but valid header 3", header_4_with_extra_whitespace
+test,2,3,4
+"test,test,test,test",3,3,5
+" even weirder, but still valid, value with linebreaks and extra
+whitespaces that should remain due to quoting   ",1,2,3
+   extra whitespaces that should get trimmed due to no quoting      ,1,2,3

--- a/src/test/resources/example-data/quoted_fields_with_newlines.ssv
+++ b/src/test/resources/example-data/quoted_fields_with_newlines.ssv
@@ -1,0 +1,6 @@
+header_1;header_2;"weird; but valid header 3"; header_4_with_extra_whitespace
+test;2;3;4
+"test;test;test;test";3;3;5
+" even weirder, but still valid; value with linebreaks and extra
+ whitespaces that should remain due to quoting   ";1;2;3
+   extra whitespaces that should get trimmed due to no quoting      ;1;2;3

--- a/src/test/resources/example-data/quoted_fields_with_newlines.tsv
+++ b/src/test/resources/example-data/quoted_fields_with_newlines.tsv
@@ -1,0 +1,6 @@
+header_1	header_2	"weird	 but valid header 3"	 header_4_with_extra_whitespace
+test	2	3	4
+"test	test	test	test"	3	3	5
+" even weirder, but still valid, value with linebreaks and extra
+ whitespaces that should remain due to quoting   "	1	2	3
+   extra whitespaces that should get trimmed due to no quoting      	1	2	3

--- a/src/test/resources/example-data/quoted_fields_with_separator.csv
+++ b/src/test/resources/example-data/quoted_fields_with_separator.csv
@@ -1,0 +1,5 @@
+header_1,header_2,"weird, but valid header 3", header_4_with_extra_whitespace
+test,2,3,4
+"test,test,test,test",3,3,5
+" even weirder, but still valid, value with extra whitespaces that remain due to quoting /  ",1,2,3
+   extra whitespaces that should get trimmed due to no quoting      ,1,2,3

--- a/src/test/resources/example-data/quoted_fields_with_separator.ssv
+++ b/src/test/resources/example-data/quoted_fields_with_separator.ssv
@@ -1,0 +1,5 @@
+header_1;header_2;"weird; but valid header 3"; header_4_with_extra_whitespace
+test;2;3;4
+"test;test;test;test";3;3;5
+" even weirder; but still valid; value with extra whitespaces that remain due to quoting /  ";1;2;3
+   extra whitespaces that should get trimmed due to no quoting      ;1;2;3

--- a/src/test/resources/example-data/quoted_fields_with_separator.tsv
+++ b/src/test/resources/example-data/quoted_fields_with_separator.tsv
@@ -1,0 +1,5 @@
+header_1	header_2	"weird	 but valid header 3"	 header_4_with_extra_whitespace
+test	2	3	4
+"test	test	test	test"	3	3	5
+" even weirder	 but still valid	 value with extra whitespaces that remain due to quoting /  "	1	2	3
+   extra whitespaces that should get trimmed due to no quoting      	1	2	3


### PR DESCRIPTION
When using the connector we ran into a few limitations of the current csv, ssv and tsv parsing that caused the connector to fail for those cases.

The specific issue we encountered was with the separator occurring in fields or headers which where then quoted to make it "legal".

An example of this is:

```
header1,header2,header3
value1,"value, 2",value3
```

Since the current parsing logic splits on all occurrences of` , `this would break, as the second line looks like it contains an additional field.

Since the project is already using jackson, which these days also supports csv parsing, it might make sense to extend the code a bit, in order to properly handle csv,ssv and tsv quoting and similar shenaningans.

This PR adds a dependency on jackson-dataformat-csv to add csv parsing functionality and replaces the current '.split(separator)' way of handling csv/ssv/tsv with the jackson parser.

**Open Questions**
1. Trimming
One thing that I noticed when implementing this is that tests failed originally, because my first implementation didn't trim whitespaces.
Personally I'd consider not trimming whitespaces to be the better behavior, as they may be there for a reason and it shouldn't be the job of this connector to guess whether they were intentional or not.
Is there a historic reason for the trimming to be there and do people rely on this functionality, or is this something that might be changed?

2. Multi Character Separators
Jackson only supports single char separators, but we currently take a String for the separator, do we envision actually supporting multi-char separators at some point? 
If not, would it make sense to change this to a char now, as this implementation currently ignores anything beyond the first character of the separator.