### PR TITLE
Update getInfo() in StorageSplit to getSplitInfo()

### DIFF
--- a/src/main/java/org/ebyhr/trino/storage/StorageSplit.java
+++ b/src/main/java/org/ebyhr/trino/storage/StorageSplit.java
@@ -15,10 +15,12 @@ package org.ebyhr.trino.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableMap;
 import io.trino.spi.HostAddress;
 import io.trino.spi.connector.ConnectorSplit;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -75,9 +77,13 @@ public class StorageSplit
     }
 
     @Override
-    public Object getInfo()
+    public Map<String, String> getSplitInfo()
     {
-        return this;
+        return ImmutableMap.<String, String>builder()
+                .put("mode", mode.name())
+                .put("schemaName", schemaName)
+                .put("tableName", tableName)
+                .buildOrThrow();
     }
 
     public enum Mode


### PR DESCRIPTION
When I read the code I found that `ConnectorSplit .getInfo()`  has the following description "getInfo is deprecated and will be removed in the future. Use getSplitInfo instead."