### PR TITLE
Add support for a pipe field delimiter in CSV files with the 'psv' plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ storage.csv."https://raw.githubusercontent.com/snowlift/trino-storage/master/src
 Supported schemas are below.
 - `tsv`
 - `csv`
+- `psv`
 - `ssv`
 - `txt`
 - `raw`
@@ -43,7 +44,7 @@ storage.csv."https://raw.githubusercontent.com/snowlift/trino-storage/master/src
 (2 rows)
 ```
 
-Tab (`\t`) and semicolon (`;`) delimiters are also supported, using the `tsv` and `ssv` plugins, respectively.
+Pipe (`|`), tab (`\t`), and semicolon (`;`) delimiters are also supported, using the `psv`, `tsv`, and `ssv` plugins, respectively.
 
 `txt` plugin doesn't extract each line. Currently column name is always `value`.
 ```sql

--- a/src/main/java/org/ebyhr/trino/storage/FileType.java
+++ b/src/main/java/org/ebyhr/trino/storage/FileType.java
@@ -17,7 +17,7 @@ import static java.util.Locale.ENGLISH;
 
 public enum FileType
 {
-    CSV, SSV, TSV, TXT, RAW, EXCEL, ORC, JSON;
+    CSV, PSV, SSV, TSV, TXT, RAW, EXCEL, ORC, JSON;
 
     @Override
     public String toString()

--- a/src/main/java/org/ebyhr/trino/storage/operator/PluginFactory.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/PluginFactory.java
@@ -30,6 +30,8 @@ public final class PluginFactory
                 return new CsvPlugin('\t');
             case "ssv":
                 return new CsvPlugin(';');
+            case "psv":
+                return new CsvPlugin('|');
             case "txt":
                 return new TextPlugin();
             case "raw":

--- a/src/test/java/org/ebyhr/trino/storage/TestStorageConnector.java
+++ b/src/test/java/org/ebyhr/trino/storage/TestStorageConnector.java
@@ -56,6 +56,21 @@ public final class TestStorageConnector
     }
 
     @Test
+    public void testSelectPsv()
+    {
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('psv', '" + toAbsolutePath("example-data/numbers-2.psv") + "'))",
+                "VALUES ('eleven', '11'), ('twelve', '12')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('psv', '" + toAbsolutePath("example-data/quoted_fields_with_separator.psv") + "'))",
+                "VALUES ('test','2','3','4'),('test|test|test|test','3','3','5'),(' even weirder| but still valid| value with extra whitespaces that remain due to quoting /  ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
+        assertQuery(
+                "SELECT * FROM TABLE(storage.system.read_file('psv', '" + toAbsolutePath("example-data/quoted_fields_with_newlines.psv") + "'))",
+                "VALUES ('test','2','3','4'),('test|test|test|test','3','3','5'),(' even weirder, but still valid| value with linebreaks and extra\n" +
+                        " whitespaces that should remain due to quoting   ','1','2','3'),('extra whitespaces that should get trimmed due to no quoting','1','2','3')");
+    }
+
+    @Test
     public void testSelectSsv()
     {
         assertQuery(

--- a/src/test/resources/example-data/numbers-2.psv
+++ b/src/test/resources/example-data/numbers-2.psv
@@ -1,0 +1,3 @@
+ten| 10
+eleven| 11
+twelve| 12

--- a/src/test/resources/example-data/quoted_fields_with_newlines.psv
+++ b/src/test/resources/example-data/quoted_fields_with_newlines.psv
@@ -1,0 +1,6 @@
+header_1|header_2|"weird| but valid header 3"| header_4_with_extra_whitespace
+test|2|3|4
+"test|test|test|test"|3|3|5
+" even weirder, but still valid| value with linebreaks and extra
+ whitespaces that should remain due to quoting   "|1|2|3
+   extra whitespaces that should get trimmed due to no quoting      |1|2|3

--- a/src/test/resources/example-data/quoted_fields_with_separator.psv
+++ b/src/test/resources/example-data/quoted_fields_with_separator.psv
@@ -1,0 +1,5 @@
+header_1|header_2|"weird| but valid header 3"| header_4_with_extra_whitespace
+test|2|3|4
+"test|test|test|test"|3|3|5
+" even weirder| but still valid| value with extra whitespaces that remain due to quoting /  "|1|2|3
+   extra whitespaces that should get trimmed due to no quoting      |1|2|3


### PR DESCRIPTION
This pull request adds support for pipe (`|`) delimited values in CSV files similar to the `ssv` and `tsv` plugins. Tests are included.