### PR TITLE
Use getConnectorPageSource for ParquetPlugin and OrcPlugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>229</version>
+        <version>234</version>
     </parent>
 
     <groupId>org.ebyhr</groupId>
     <artifactId>trino-storage</artifactId>
-    <version>473-SNAPSHOT</version>
+    <version>474-SNAPSHOT</version>
     <packaging>trino-plugin</packaging>
     <description>Trino - Storage Connector</description>
 
@@ -46,28 +46,28 @@
         <air.check.skip-checkstyle>false</air.check.skip-checkstyle>
         <air.build.jvmsize>4g</air.build.jvmsize>
 
-        <dep.trino.version>472</dep.trino.version>
-        <dep.airlift.version>312</dep.airlift.version>
+        <dep.trino.version>474</dep.trino.version>
+        <dep.airlift.version>319</dep.airlift.version>
         <dep.aircompressor.version>2.0.2</dep.aircompressor.version>
         <dep.slice.version>2.3</dep.slice.version>
-        <dep.opentelemetry.version>1.47.0</dep.opentelemetry.version>
-        <dep.opentelemetry-instrumentation.version>2.13.3</dep.opentelemetry-instrumentation.version>
+        <dep.opentelemetry.version>1.48.0</dep.opentelemetry.version>
+        <dep.opentelemetry-instrumentation.version>2.14.0</dep.opentelemetry-instrumentation.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.aws-sdk.version>1.12.782</dep.aws-sdk.version>
-        <dep.guava.version>33.4.0-jre</dep.guava.version>
+        <dep.guava.version>33.4.5-jre</dep.guava.version>
         <dep.guice.version>7.0.0</dep.guice.version>
-        <dep.errorprone.version>2.36.0</dep.errorprone.version>
+        <dep.errorprone.version>2.37.0</dep.errorprone.version>
         <dep.jackson.version>2.18.3</dep.jackson.version>
         <dep.testcontainers.version>1.20.6</dep.testcontainers.version>
-        <dep.docker-java.version>3.4.1</dep.docker-java.version>
+        <dep.docker-java.version>3.4.2</dep.docker-java.version>
         <dep.joda.version>2.13.1</dep.joda.version>
-        <dep.junit.version>5.12.0</dep.junit.version>
+        <dep.junit.version>5.12.1</dep.junit.version>
         <dep.slf4j.version>2.0.17</dep.slf4j.version>
         <dep.assertj-core.version>3.27.3</dep.assertj-core.version>
-        <dep.logback.version>1.5.17</dep.logback.version>
-        <dep.parquet.version>1.15.0</dep.parquet.version>
+        <dep.logback.version>1.5.18</dep.logback.version>
+        <dep.parquet.version>1.15.1</dep.parquet.version>
         <dep.plugin.surefire.version>3.2.5</dep.plugin.surefire.version>
-        <dep.jna.version>5.16.0</dep.jna.version>
+        <dep.jna.version>5.17.0</dep.jna.version>
 
         <project.scm.id>github</project.scm.id>
     </properties>
@@ -218,6 +218,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.trino</groupId>
+            <artifactId>trino-plugin-toolkit</artifactId>
+            <version>${dep.trino.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
             <version>1</version>
@@ -333,13 +339,6 @@
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <version>1.10</version>
-            <scope>runtime</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.trino</groupId>
-            <artifactId>trino-plugin-toolkit</artifactId>
-            <version>${dep.trino.version}</version>
             <scope>runtime</scope>
         </dependency>
 

--- a/src/main/java/org/ebyhr/trino/storage/StoragePageSourceProvider.java
+++ b/src/main/java/org/ebyhr/trino/storage/StoragePageSourceProvider.java
@@ -68,6 +68,14 @@ public class StoragePageSourceProvider
         FilePlugin plugin = PluginFactory.create(schemaName);
 
         try {
+            return plugin.getConnectorPageSource(tableName, path -> storageClient.getInputStream(session, path));
+        }
+        catch (UnsupportedOperationException ignored) {
+            // Ignore it when a plugin doesn't implement getConnectorPageSource
+            // and assume it implements getPagesIterator or getRecordsIterator
+        }
+
+        try {
             Iterable<Page> iterable = plugin.getPagesIterator(tableName, path -> storageClient.getInputStream(session, path));
             List<Page> pages = StreamSupport.stream(iterable.spliterator(), false)
                     .collect(toList());

--- a/src/main/java/org/ebyhr/trino/storage/operator/FilePlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/FilePlugin.java
@@ -14,6 +14,7 @@
 package org.ebyhr.trino.storage.operator;
 
 import io.trino.spi.Page;
+import io.trino.spi.connector.ConnectorPageSource;
 import org.ebyhr.trino.storage.StorageColumnHandle;
 
 import java.io.InputStream;
@@ -27,11 +28,16 @@ public interface FilePlugin
 
     default Stream<List<?>> getRecordsIterator(String path, Function<String, InputStream> streamProvider)
     {
-        throw new UnsupportedOperationException("A FilePlugin must implement either getRecordsIterator or getPagesIterator");
+        throw new UnsupportedOperationException("A FilePlugin must implement getConnectorPageSource, getRecordsIterator or getPagesIterator");
     }
 
     default Iterable<Page> getPagesIterator(String path, Function<String, InputStream> streamProvider)
     {
-        throw new UnsupportedOperationException("A FilePlugin must implement either getPagesIterator or getRecordsIterator");
+        throw new UnsupportedOperationException("A FilePlugin must implement getConnectorPageSource, getRecordsIterator or getPagesIterator");
+    }
+
+    default ConnectorPageSource getConnectorPageSource(String path, Function<String, InputStream> streamProvider)
+    {
+        throw new UnsupportedOperationException("A FilePlugin must implement getConnectorPageSource, getRecordsIterator or getPagesIterator");
     }
 }

--- a/src/main/java/org/ebyhr/trino/storage/operator/OrcPageSource.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/OrcPageSource.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ebyhr.trino.storage.operator;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Closer;
+import io.trino.memory.context.AggregatedMemoryContext;
+import io.trino.memory.context.LocalMemoryContext;
+import io.trino.orc.OrcCorruptionException;
+import io.trino.orc.OrcDataSource;
+import io.trino.orc.OrcDataSourceId;
+import io.trino.orc.OrcRecordReader;
+import io.trino.orc.metadata.CompressionKind;
+import io.trino.plugin.base.metrics.FileFormatDataSourceStats;
+import io.trino.plugin.base.metrics.LongCount;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.metrics.Metrics;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class OrcPageSource
+        implements ConnectorPageSource
+{
+    private static final String ORC_CODEC_METRIC_PREFIX = "OrcReaderCompressionFormat_";
+
+    private final OrcRecordReader recordReader;
+    private final OrcDataSource orcDataSource;
+    private final AggregatedMemoryContext memoryContext;
+    private final LocalMemoryContext localMemoryContext;
+    private final FileFormatDataSourceStats stats;
+    private final CompressionKind compressionKind;
+    private boolean closed;
+    private long completedPositions;
+
+    private Optional<SourcePage> outstandingPage = Optional.empty();
+
+    public OrcPageSource(
+            OrcRecordReader recordReader,
+            OrcDataSource orcDataSource,
+            AggregatedMemoryContext memoryContext,
+            FileFormatDataSourceStats stats,
+            CompressionKind compressionKind)
+    {
+        this.recordReader = requireNonNull(recordReader, "recordReader is null");
+        this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
+        this.stats = requireNonNull(stats, "stats is null");
+        this.memoryContext = requireNonNull(memoryContext, "memoryContext is null");
+        this.localMemoryContext = memoryContext.newLocalMemoryContext(OrcPageSource.class.getSimpleName());
+        this.compressionKind = requireNonNull(compressionKind, "compressionKind is null");
+    }
+
+    static TrinoException handleException(OrcDataSourceId dataSourceId, Exception exception)
+    {
+        if (exception instanceof TrinoException trinoException) {
+            return trinoException;
+        }
+        if (exception instanceof OrcCorruptionException) {
+            return new TrinoException(GENERIC_INTERNAL_ERROR, exception);
+        }
+        return new TrinoException(GENERIC_INTERNAL_ERROR, format("Failed to read ORC file: %s", dataSourceId), exception);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return orcDataSource.getReadBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return orcDataSource.getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed;
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        SourcePage page;
+        try {
+            if (outstandingPage.isPresent()) {
+                page = outstandingPage.get();
+                outstandingPage = Optional.empty();
+                // Mark no bytes consumed by outstandingPage.
+                // We can reset it again below if deletedRows loading yields again.
+                // In such case the brief period when it is set to 0 will not be observed externally as
+                // page source memory usage is only read by engine after call to getNextPage completes.
+                localMemoryContext.setBytes(0);
+            }
+            else {
+                page = recordReader.nextPage();
+            }
+        }
+        catch (IOException | RuntimeException e) {
+            closeAllSuppress(e, this);
+            throw handleException(orcDataSource.getId(), e);
+        }
+
+        if (page == null) {
+            close();
+            return null;
+        }
+
+        completedPositions += page.getPositionCount();
+
+        return page;
+    }
+
+    @Override
+    public void close()
+    {
+        // some hive input formats are broken and bad things can happen if you close them multiple times
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        Closer closer = Closer.create();
+
+        closer.register(() -> {
+            stats.addMaxCombinedBytesPerRow(recordReader.getMaxCombinedBytesPerRow());
+            recordReader.close();
+        });
+
+        try {
+            closer.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("orcReader", recordReader)
+                .toString();
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return memoryContext.getBytes();
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return new Metrics(ImmutableMap.of(ORC_CODEC_METRIC_PREFIX + compressionKind.name(), new LongCount(recordReader.getTotalDataLength())));
+    }
+}

--- a/src/main/java/org/ebyhr/trino/storage/operator/ParquetPageSource.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/ParquetPageSource.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ebyhr.trino.storage.operator;
+
+import io.trino.parquet.ParquetCorruptionException;
+import io.trino.parquet.ParquetDataSourceId;
+import io.trino.parquet.reader.ParquetReader;
+import io.trino.spi.TrinoException;
+import io.trino.spi.connector.ConnectorPageSource;
+import io.trino.spi.connector.SourcePage;
+import io.trino.spi.metrics.Metrics;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.OptionalLong;
+
+import static io.trino.plugin.base.util.Closables.closeAllSuppress;
+import static io.trino.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ParquetPageSource
+        implements ConnectorPageSource
+{
+    private final ParquetReader parquetReader;
+
+    private boolean closed;
+    private long completedPositions;
+
+    public ParquetPageSource(ParquetReader parquetReader)
+    {
+        this.parquetReader = requireNonNull(parquetReader, "parquetReader is null");
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return parquetReader.getDataSource().getReadBytes();
+    }
+
+    @Override
+    public OptionalLong getCompletedPositions()
+    {
+        return OptionalLong.of(completedPositions);
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return parquetReader.getDataSource().getReadTimeNanos();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return closed;
+    }
+
+    @Override
+    public long getMemoryUsage()
+    {
+        return parquetReader.getMemoryContext().getBytes();
+    }
+
+    @Override
+    public SourcePage getNextSourcePage()
+    {
+        SourcePage page;
+        try {
+            page = parquetReader.nextPage();
+        }
+        catch (IOException | RuntimeException e) {
+            closeAllSuppress(e, this);
+            throw handleException(parquetReader.getDataSource().getId(), e);
+        }
+
+        if (closed || page == null) {
+            close();
+            return null;
+        }
+
+        completedPositions += page.getPositionCount();
+        return page;
+    }
+
+    @Override
+    public void close()
+    {
+        if (closed) {
+            return;
+        }
+        closed = true;
+
+        try {
+            parquetReader.close();
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public Metrics getMetrics()
+    {
+        return parquetReader.getMetrics();
+    }
+
+    static TrinoException handleException(ParquetDataSourceId dataSourceId, Exception exception)
+    {
+        if (exception instanceof TrinoException trinoException) {
+            return trinoException;
+        }
+        if (exception instanceof ParquetCorruptionException) {
+            return new TrinoException(GENERIC_INTERNAL_ERROR, exception);
+        }
+        return new TrinoException(GENERIC_INTERNAL_ERROR, format("Failed to read Parquet file: %s", dataSourceId), exception);
+    }
+}


### PR DESCRIPTION
Instead of using `FixedPageSource` for Parquet and Orc, we can just return their dedicated `PageSource`