### PR TITLE
(#388) support_selecting_specific_columns

### DIFF
--- a/src/main/java/org/ebyhr/trino/storage/StoragePageSourceProvider.java
+++ b/src/main/java/org/ebyhr/trino/storage/StoragePageSourceProvider.java
@@ -68,7 +68,11 @@ public class StoragePageSourceProvider
         FilePlugin plugin = PluginFactory.create(schemaName);
 
         try {
-            return plugin.getConnectorPageSource(tableName, path -> storageClient.getInputStream(session, path));
+            List<String> handles = columns.stream()
+                    .map(c -> (StorageColumnHandle) c)
+                    .map(c -> c.getName().toLowerCase())
+                    .toList();
+            return plugin.getConnectorPageSource(tableName, handles, path -> storageClient.getInputStream(session, path));
         }
         catch (UnsupportedOperationException ignored) {
             // Ignore it when a plugin doesn't implement getConnectorPageSource

--- a/src/main/java/org/ebyhr/trino/storage/operator/FilePlugin.java
+++ b/src/main/java/org/ebyhr/trino/storage/operator/FilePlugin.java
@@ -36,7 +36,7 @@ public interface FilePlugin
         throw new UnsupportedOperationException("A FilePlugin must implement getConnectorPageSource, getRecordsIterator or getPagesIterator");
     }
 
-    default ConnectorPageSource getConnectorPageSource(String path, Function<String, InputStream> streamProvider)
+    default ConnectorPageSource getConnectorPageSource(String path, List<String> handleColumns, Function<String, InputStream> streamProvider)
     {
         throw new UnsupportedOperationException("A FilePlugin must implement getConnectorPageSource, getRecordsIterator or getPagesIterator");
     }


### PR DESCRIPTION
### Background
 - some file types which implements `getConnectorPageSource` doesn't support selecting specific columns
   - read in order from the front, it cannot be read if the column type is changed.

<img width="1123" alt="스크린샷 2025-04-24 오전 12 42 37" src="https://github.com/user-attachments/assets/d6bc1849-baaf-428d-8bef-fbb4e4ea803c" />

 - fail to select specific columns from parquet type

<img width="1109" alt="스크린샷 2025-04-24 오전 12 44 37" src="https://github.com/user-attachments/assets/2dcadf16-71d8-4616-9e16-a7148b66735a" />

 - fail to select specific columns from orc type 

---

<img width="679" alt="스크린샷 2025-04-24 오전 12 45 58" src="https://github.com/user-attachments/assets/9a07e834-1d9b-4754-8be2-433120320a91" />

<img width="723" alt="스크린샷 2025-04-24 오전 12 45 45" src="https://github.com/user-attachments/assets/0aa76c48-113f-476f-a5bd-c042b8b58da2" />

 - now, it supports selecting specific columns
 - @nineinchnick Hi, could you please take a look?
